### PR TITLE
[chore] relaxed dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=readme(),
     long_description_content_type="text/markdown",
     install_requires=[
-        "construct<=2.10.61",
+        "construct>=2.10.61",
         "rlp>=2,<3",
         "ledgerwallet",
     ],


### PR DESCRIPTION
Hi there.

We were having problems integrating this into our ledger.

https://github.com/valory-xyz/open-aea/tree/main/plugins

To be used in conjunction with;

https://github.com/valory-xyz/open-autonomy

If at all possible, would you consider relaxing this requirement?

I believe that all tests will be unaffected.